### PR TITLE
Misc improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ increase the JavaScript heap size by adding `--max-old-space-size=4096` for Node
 
 #### getClientContext
 
-[src/index.mjs:11-21](https://github.com/Safe-DEED/PSA/blob/master/src/index.mjs#L11-L21 'Source code on GitHub')
+[src/index.mjs:12-24](https://github.com/Safe-DEED/PSA/blob/master/src/index.mjs#L12-L24 'Source code on GitHub')
 
 This asynchronous function return the client context object.
 
@@ -89,7 +89,7 @@ Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/G
 
 #### getServerContext
 
-[src/index.mjs:30-40](https://github.com/Safe-DEED/PSA/blob/master/src/index.mjs#L30-L40 'Source code on GitHub')
+[src/index.mjs:34-46](https://github.com/Safe-DEED/PSA/blob/master/src/index.mjs#L34-L46'Source code on GitHub')
 
 This asynchronous function return the server context object.
 
@@ -106,7 +106,7 @@ Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/G
 
 #### encrypt
 
-[src/index.mjs:73-99](https://github.com/Safe-DEED/PSA/blob/master/src/index.mjs#L73-L99 'Source code on GitHub')
+[src/index.mjs:79-105](https://github.com/Safe-DEED/PSA/blob/master/src/index.mjs#L79-L105 'Source code on GitHub')
 
 This function encrypts the client's input vector and returns an array of ciphertexts.
 
@@ -119,7 +119,7 @@ Returns **[array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Gl
 
 #### encryptForClientRequest
 
-[src/index.mjs:107-120](https://github.com/Safe-DEED/PSA/blob/master/src/index.mjs#L107-L120 'Source code on GitHub')
+[src/index.mjs:113-126](https://github.com/Safe-DEED/PSA/blob/master/src/index.mjs#L113-L126 'Source code on GitHub')
 
 This function encrypts the client's input vector and returns an object ready to be sent to the server.
 
@@ -132,7 +132,7 @@ Returns **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/G
 
 #### decrypt
 
-[src/index.mjs:128-146](https://github.com/Safe-DEED/PSA/blob/master/src/index.mjs#L128-L146 'Source code on GitHub')
+[src/index.mjs:134-152](https://github.com/Safe-DEED/PSA/blob/master/src/index.mjs#L134-L152 'Source code on GitHub')
 
 This function decrypts the computed result vector. The result will be in the first n cells, if the matrix was of dimension (m x n).
 
@@ -145,7 +145,7 @@ Returns **[array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Gl
 
 #### decryptServerResponseObject
 
-[src/index.mjs:154-157](https://github.com/Safe-DEED/PSA/blob/master/src/index.mjs#L154-L157 'Source code on GitHub')
+[src/index.mjs:160-163](https://github.com/Safe-DEED/PSA/blob/master/src/index.mjs#L160-L163 'Source code on GitHub')
 
 This function decrypts the server response object. The result will be in the first n cells, if the matrix was of dimension (m x n).
 
@@ -158,7 +158,7 @@ Returns **[array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Gl
 
 #### getSerializedGaloisKeys
 
-[src/index.mjs:201-203](https://github.com/Safe-DEED/PSA/blob/master/src/index.mjs#L201-L203 'Source code on GitHub')
+[src/index.mjs:207-209](https://github.com/Safe-DEED/PSA/blob/master/src/index.mjs#L207-L209 'Source code on GitHub')
 
 This function returns the serialized galois key needed for rotations of the ciphertext.
 
@@ -170,7 +170,7 @@ Returns **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/G
 
 #### compute
 
-[src/index.mjs:168-194](https://github.com/Safe-DEED/PSA/blob/master/src/index.mjs#L168-L194 'Source code on GitHub')
+[src/index.mjs:174-200](https://github.com/Safe-DEED/PSA/blob/master/src/index.mjs#L174-L200 'Source code on GitHub')
 
 This function computes the dot product between the encrypted client vector and the server matrix.
 Constraints: If vector is of dimensions (1 x m), then matrix has to be of (m x n).
@@ -186,7 +186,7 @@ Returns **[array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Gl
 
 #### computeWithClientRequestObject
 
-[src/index.mjs:213-230](https://github.com/Safe-DEED/PSA/blob/master/src/index.mjs#L213-L230 'Source code on GitHub')
+[src/index.mjs:219-236](https://github.com/Safe-DEED/PSA/blob/master/src/index.mjs#L219-L236 'Source code on GitHub')
 
 This function computes the dot product between the encrypted client vector and the server matrix.
 Constraints: If vector is of dimensions (1 x m), then matrix has to be of (m x n).

--- a/README.md
+++ b/README.md
@@ -72,35 +72,41 @@ increase the JavaScript heap size by adding `--max-old-space-size=4096` for Node
 
 #### getClientContext
 
-[src/index.mjs:11-13](https://github.com/Safe-DEED/PSA/blob/2bdaec3efffe284c0299eb11f291cd9b9cea6a08/src/index.mjs#L11-L13 'Source code on GitHub')
+[src/index.mjs:11-21](https://github.com/Safe-DEED/PSA/blob/master/src/index.mjs#L11-L21 'Source code on GitHub')
 
 This asynchronous function return the client context object.
 
 ##### Parameters
 
+Accepts an Object with the following keys:
+
 - `polyModulusDegree` **[number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** the polymodulus degree
 - `plainModulus` **[number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** the plaintext modulus
-- `compressionMode` **[string<'none'|'zlib'|'zstd'>](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/string)** the compressino mode to use
+- `securityLevel` **[number<128|192|256>](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** the security level to use. Defaults to 128 bits.
+- `compressionMode` **[string<'none'|'zlib'|'zstd'>](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/string)** the compressino mode to use. Defaults to 'zstd'
 
 Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** a context object necessary for client side actions
 
 #### getServerContext
 
-[src/index.mjs:21-23](https://github.com/Safe-DEED/PSA/blob/2bdaec3efffe284c0299eb11f291cd9b9cea6a08/src/index.mjs#L21-L23 'Source code on GitHub')
+[src/index.mjs:30-40](https://github.com/Safe-DEED/PSA/blob/master/src/index.mjs#L30-L40 'Source code on GitHub')
 
 This asynchronous function return the server context object.
 
 ##### Parameters
 
+Accepts an Object with the following keys:
+
 - `polyModulusDegree` **[number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** the polymodulus degree
 - `plainModulus` **[number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** the plaintext modulus
-- `compressionMode` **[string<'none'|'zlib'|'zstd'>](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/string)** the compressino mode to use
+- `securityLevel` **[number<128|192|256>](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** the security level to use. Defaults to 128 bits.
+- `compressionMode` **[string<'none'|'zlib'|'zstd'>](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/string)** the compressino mode to use. Defaults to 'zstd'
 
 Returns **[Object](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Object)** a context object necessary for client side actions
 
 #### encrypt
 
-[src/index.mjs:58-76](https://github.com/Safe-DEED/PSA/blob/2bdaec3efffe284c0299eb11f291cd9b9cea6a08/src/index.mjs#L58-L76 'Source code on GitHub')
+[src/index.mjs:73-99](https://github.com/Safe-DEED/PSA/blob/master/src/index.mjs#L73-L99 'Source code on GitHub')
 
 This function encrypts the client's input vector and returns an array of ciphertexts.
 
@@ -113,7 +119,7 @@ Returns **[array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Gl
 
 #### encryptForClientRequest
 
-[src/index.mjs:84-87](https://github.com/Safe-DEED/PSA/blob/2bdaec3efffe284c0299eb11f291cd9b9cea6a08/src/index.mjs#L84-L87 'Source code on GitHub')
+[src/index.mjs:107-120](https://github.com/Safe-DEED/PSA/blob/master/src/index.mjs#L107-L120 'Source code on GitHub')
 
 This function encrypts the client's input vector and returns an object ready to be sent to the server.
 
@@ -126,7 +132,7 @@ Returns **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/G
 
 #### decrypt
 
-[src/index.mjs:105-130](https://github.com/Safe-DEED/PSA/blob/2bdaec3efffe284c0299eb11f291cd9b9cea6a08/src/index.mjs#L105-L130 'Source code on GitHub')
+[src/index.mjs:128-146](https://github.com/Safe-DEED/PSA/blob/master/src/index.mjs#L128-L146 'Source code on GitHub')
 
 This function decrypts the computed result vector. The result will be in the first n cells, if the matrix was of dimension (m x n).
 
@@ -139,7 +145,7 @@ Returns **[array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Gl
 
 #### decryptServerResponseObject
 
-[src/index.mjs:138-141](https://github.com/Safe-DEED/PSA/blob/2bdaec3efffe284c0299eb11f291cd9b9cea6a08/src/index.mjs#L138-L141 'Source code on GitHub')
+[src/index.mjs:154-157](https://github.com/Safe-DEED/PSA/blob/master/src/index.mjs#L154-L157 'Source code on GitHub')
 
 This function decrypts the server response object. The result will be in the first n cells, if the matrix was of dimension (m x n).
 
@@ -152,7 +158,7 @@ Returns **[array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Gl
 
 #### getSerializedGaloisKeys
 
-[src/index.mjs:148-150](https://github.com/Safe-DEED/PSA/blob/2bdaec3efffe284c0299eb11f291cd9b9cea6a08/src/index.mjs#L148-L150 'Source code on GitHub')
+[src/index.mjs:201-203](https://github.com/Safe-DEED/PSA/blob/master/src/index.mjs#L201-L203 'Source code on GitHub')
 
 This function returns the serialized galois key needed for rotations of the ciphertext.
 
@@ -164,7 +170,7 @@ Returns **[string](https://developer.mozilla.org/docs/Web/JavaScript/Reference/G
 
 #### compute
 
-[src/index.mjs:161-190](https://github.com/Safe-DEED/PSA/blob/2bdaec3efffe284c0299eb11f291cd9b9cea6a08/src/index.mjs#L161-L190 'Source code on GitHub')
+[src/index.mjs:168-194](https://github.com/Safe-DEED/PSA/blob/master/src/index.mjs#L168-L194 'Source code on GitHub')
 
 This function computes the dot product between the encrypted client vector and the server matrix.
 Constraints: If vector is of dimensions (1 x m), then matrix has to be of (m x n).
@@ -180,7 +186,7 @@ Returns **[array](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Gl
 
 #### computeWithClientRequestObject
 
-[src/index.mjs:200-205](https://github.com/Safe-DEED/PSA/blob/2bdaec3efffe284c0299eb11f291cd9b9cea6a08/src/index.mjs#L200-L205 'Source code on GitHub')
+[src/index.mjs:213-230](https://github.com/Safe-DEED/PSA/blob/master/src/index.mjs#L213-L230 'Source code on GitHub')
 
 This function computes the dot product between the encrypted client vector and the server matrix.
 Constraints: If vector is of dimensions (1 x m), then matrix has to be of (m x n).

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ This asynchronous function return the client context object.
 Accepts an Object with the following keys:
 
 - `polyModulusDegree` **[number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** the polymodulus degree
-- `plainModulus` **[number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** the plaintext modulus
+- `plainModulusBitSize` **[number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** the plaintext modulus
 - `securityLevel` **[number<128|192|256>](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** the security level to use. Defaults to 128 bits.
 - `compressionMode` **[string<'none'|'zlib'|'zstd'>](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/string)** the compressino mode to use. Defaults to 'zstd'
 
@@ -98,7 +98,7 @@ This asynchronous function return the server context object.
 Accepts an Object with the following keys:
 
 - `polyModulusDegree` **[number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** the polymodulus degree
-- `plainModulus` **[number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** the plaintext modulus
+- `plainModulusBitSize` **[number](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** the plaintext modulus
 - `securityLevel` **[number<128|192|256>](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Number)** the security level to use. Defaults to 128 bits.
 - `compressionMode` **[string<'none'|'zlib'|'zstd'>](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/string)** the compressino mode to use. Defaults to 'zstd'
 

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "url": "https://github.com/Safe-DEED/PSA"
   },
   "dependencies": {
-    "node-seal": "^4.5.0"
+    "node-seal": "^4.5.1"
   },
   "devDependencies": {
     "@babel/cli": "^7.12.8",

--- a/src/HEutil.js
+++ b/src/HEutil.js
@@ -30,6 +30,7 @@ async function createHEContext(polyModulusDegree, securityLevel, plainModulusBit
   true, // ExpandModChain
   secLevel // Enforce a security level
   );
+  parms.delete();
 
   if (!context.parametersSet()) {
     throw new Error('Could not set the parameters in the given context. Please try different encryption parameters.');

--- a/src/HEutil.js
+++ b/src/HEutil.js
@@ -10,50 +10,94 @@ var _allows_wasm_node_umd = _interopRequireDefault(require("node-seal/allows_was
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
-async function createHEContext(polyModulusDegree, plainModulus) {
-  // TODO: If it is possible for the application to create multiple client/server contexts,
-  // we should move this out into a global singleton as it will trigger a warning
-  // related to too many listeners (how WASM signals it is initialized internally).
-  const Morfix = await (0, _allows_wasm_node_umd.default)();
-  const schemeType = Morfix.SchemeType.bfv;
-  const securityLevel = Morfix.SecurityLevel.tc128;
-  let bitSizes;
+async function createHEContext(polyModulusDegree, securityLevel, plainModulusBitSize) {
+  const seal = await (0, _allows_wasm_node_umd.default)();
+  const schemeType = seal.SchemeType.bfv;
+  const secLevel = getSecurityLevel(securityLevel, seal);
+  const parms = seal.EncryptionParameters(schemeType); // Set the PolyModulusDegree
 
-  switch (polyModulusDegree) {
-    case 4096:
-      bitSizes = [36, 36, 37];
-      break;
+  parms.setPolyModulusDegree(polyModulusDegree); // Create a suitable set of CoeffModulus primes.
+  // We use the default helper
 
-    case 8192:
-      bitSizes = [43, 43, 44, 44, 44];
-      break;
+  const coeffModulus = seal.CoeffModulus.BFVDefault(polyModulusDegree, secLevel);
+  parms.setCoeffModulus(coeffModulus);
+  coeffModulus.delete(); // Create and set the PlainModulus to a prime of bitSize
 
-    case 16384:
-      bitSizes = [48, 48, 48, 49, 49, 49, 49, 49, 49];
-      break;
-
-    default:
-      throw new Error('unknown polyModulusDegree ' + polyModulusDegree);
-  }
-
-  const bitSize = plainModulus;
-  const parms = Morfix.EncryptionParameters(schemeType); // Set the PolyModulusDegree
-
-  parms.setPolyModulusDegree(polyModulusDegree); // Create a suitable set of CoeffModulus primes
-
-  parms.setCoeffModulus(Morfix.CoeffModulus.Create(polyModulusDegree, Int32Array.from(bitSizes))); // Set the PlainModulus to a prime of bitSize 20.
-
-  parms.setPlainModulus(Morfix.PlainModulus.Batching(polyModulusDegree, bitSize));
-  const context = Morfix.Context(parms, // Encryption Parameters
+  const plainModulus = seal.PlainModulus.Batching(polyModulusDegree, plainModulusBitSize);
+  parms.setPlainModulus(plainModulus);
+  plainModulus.delete();
+  const context = seal.Context(parms, // Encryption Parameters
   true, // ExpandModChain
-  securityLevel // Enforce a security level
+  secLevel // Enforce a security level
   );
 
   if (!context.parametersSet()) {
     throw new Error('Could not set the parameters in the given context. Please try different encryption parameters.');
   }
 
-  return [Morfix, context];
+  return [seal, context];
+}
+
+async function createClientHEContext(polyModulusDegree, plainModulus, securityLevel, compressionMode) {
+  const [seal, context] = await createHEContext(polyModulusDegree, securityLevel, plainModulus);
+  const encoder = seal.BatchEncoder(context);
+  const keyGenerator = seal.KeyGenerator(context);
+  const publicKey = keyGenerator.createPublicKey();
+  const secretKey = keyGenerator.secretKey(); // Use the `createGaloisKeysSerializable` function which generates a `Serializable` object
+  // ready to be serialized. The benefit is about a 50% reduction in size,
+  // but you cannot perform any HE operations until it is deserialized into
+  // a proper GaloisKeys instance.
+
+  const galoisKeys = keyGenerator.createGaloisKeysSerializable();
+  const encryptor = seal.Encryptor(context, publicKey);
+  const decryptor = seal.Decryptor(context, secretKey);
+  const evaluator = seal.Evaluator(context);
+  const compression = getComprModeType(compressionMode, seal);
+  return {
+    seal,
+    compression,
+    context,
+    encoder,
+    keyGenerator,
+    publicKey,
+    secretKey,
+    galoisKeys,
+    encryptor,
+    decryptor,
+    evaluator
+  };
+}
+
+async function createServerHEContext(polyModulusDegree, plainModulus, securityLevel, compressionMode) {
+  const [seal, context] = await createHEContext(polyModulusDegree, securityLevel, plainModulus);
+  const encoder = seal.BatchEncoder(context);
+  const evaluator = seal.Evaluator(context);
+  const compression = getComprModeType(compressionMode, seal);
+  return {
+    seal,
+    compression,
+    context,
+    encoder,
+    evaluator
+  };
+}
+
+function getSecurityLevel(securityLevel, {
+  SecurityLevel
+}) {
+  switch (securityLevel) {
+    case 128:
+      return SecurityLevel.tc128;
+
+    case 192:
+      return SecurityLevel.tc192;
+
+    case 256:
+      return SecurityLevel.tc256;
+
+    default:
+      return SecurityLevel.tc128;
+  }
 }
 
 function getComprModeType(compression, {
@@ -72,48 +116,4 @@ function getComprModeType(compression, {
     default:
       return ComprModeType.zstd;
   }
-}
-
-async function createClientHEContext(polyModulusDegree, plainModulus, compressionMode) {
-  const [morfix, context] = await createHEContext(polyModulusDegree, plainModulus);
-  const encoder = morfix.BatchEncoder(context);
-  const keyGenerator = morfix.KeyGenerator(context);
-  const publicKey = keyGenerator.createPublicKey();
-  const secretKey = keyGenerator.secretKey(); // Use the `createGaloisKeysSerializable` function which generates a `Serializable` object
-  // ready to be serialized. The benefit is about a 50% reduction in size,
-  // but you cannot perform any HE operations until it is deserialized into
-  // a proper GaloisKeys instance.
-
-  const galoisKeys = keyGenerator.createGaloisKeysSerializable();
-  const encryptor = morfix.Encryptor(context, publicKey);
-  const decryptor = morfix.Decryptor(context, secretKey);
-  const evaluator = morfix.Evaluator(context);
-  const compression = getComprModeType(compressionMode, morfix);
-  return {
-    morfix,
-    compression,
-    context,
-    encoder,
-    keyGenerator,
-    publicKey,
-    secretKey,
-    galoisKeys,
-    encryptor,
-    decryptor,
-    evaluator
-  };
-}
-
-async function createServerHEContext(polyModulusDegree, plainModulus, compressionMode) {
-  const [morfix, context] = await createHEContext(polyModulusDegree, plainModulus);
-  const encoder = morfix.BatchEncoder(context);
-  const evaluator = morfix.Evaluator(context);
-  const compression = getComprModeType(compressionMode, morfix);
-  return {
-    morfix,
-    compression,
-    context,
-    encoder,
-    evaluator
-  };
 }

--- a/src/HEutil.mjs
+++ b/src/HEutil.mjs
@@ -34,6 +34,7 @@ async function createHEContext(
     true, // ExpandModChain
     secLevel // Enforce a security level
   )
+  parms.delete()
 
   if (!context.parametersSet()) {
     throw new Error(

--- a/src/MatMul.js
+++ b/src/MatMul.js
@@ -86,7 +86,7 @@ function rotateN(arr, n, toTheRight) {
 }
 
 function babyStepGiantStepMatMul(inputState, subMatrix, {
-  morfix,
+  seal,
   encoder,
   context,
   evaluator,
@@ -122,10 +122,10 @@ function babyStepGiantStepMatMul(inputState, subMatrix, {
     matrix.push(row);
   }
 
-  const outerSum = morfix.CipherText({
+  const outerSum = seal.CipherText({
     context
   });
-  const innerSum = morfix.CipherText({
+  const innerSum = seal.CipherText({
     context
   }); // prepare rotations
 

--- a/src/MatMul.mjs
+++ b/src/MatMul.mjs
@@ -78,7 +78,7 @@ function rotateN(arr, n, toTheRight) {
 function babyStepGiantStepMatMul(
   inputState,
   subMatrix,
-  { morfix, encoder, context, evaluator, galois },
+  { seal, encoder, context, evaluator, galois },
   bsgsN1,
   bsgsN2
 ) {
@@ -112,8 +112,8 @@ function babyStepGiantStepMatMul(
     matrix.push(row)
   }
 
-  const outerSum = morfix.CipherText({ context })
-  const innerSum = morfix.CipherText({ context })
+  const outerSum = seal.CipherText({ context })
+  const innerSum = seal.CipherText({ context })
 
   // prepare rotations
   const rot = [] //size: bsgsN1

--- a/src/index.js
+++ b/src/index.js
@@ -12,24 +12,36 @@ var _MatMul = require("./MatMul");
 /**
  * This asynchronous function return the client context object.
  * @param {number} polyModulusDegree the polymodulus degree
- * @param {number} plainModulus the plaintext modulus
- * @param {('none'|'zlib'|'zstd')} [compressionMode='zstd'] Optional compression mode for serialization
+ * @param {number} plainModulusBitSize the bit size of the plaintext modulus prime that will be generated
+ * @param {(128|192|256)} [securityLevel=128] the security level in bits (default = 128)
+ * @param {('none'|'zlib'|'zstd')} [compressionMode='zstd'] Optional compression mode for serialization (default = zstd)
  * @returns {Object} a context object necessary for client side actions
  */
-async function getClientContext(polyModulusDegree, plainModulus, compressionMode = 'zstd') {
-  return await (0, _HEutil.createClientHEContext)(polyModulusDegree, plainModulus, compressionMode);
+async function getClientContext({
+  polyModulusDegree,
+  plainModulusBitSize,
+  securityLevel = 128,
+  compressionMode = 'zstd'
+}) {
+  return await (0, _HEutil.createClientHEContext)(polyModulusDegree, plainModulusBitSize, securityLevel, compressionMode);
 }
 /**
  * This asynchronous function return the server context object.
  * @param {number} polyModulusDegree the polymodulus degree
- * @param {number} plainModulus the plaintext modulus
- * @param {('none'|'zlib'|'zstd')} [compressionMode='zstd'] Optional compression mode for serialization
+ * @param {number} plainModulusBitSize the bit size of the plaintext modulus prime that will be generated
+ * @param {(128|192|256)} [securityLevel=128] the security level in bits (default = 128)
+ * @param {('none'|'zlib'|'zstd')} [compressionMode='zstd'] Optional compression mode for serialization (default = zstd)
  * @returns {Object} a context object necessary for client side actions
  */
 
 
-async function getServerContext(polyModulusDegree, plainModulus, compressionMode = 'zstd') {
-  return await (0, _HEutil.createServerHEContext)(polyModulusDegree, plainModulus, compressionMode);
+async function getServerContext({
+  polyModulusDegree,
+  plainModulusBitSize,
+  securityLevel = 128,
+  compressionMode = 'zstd'
+}) {
+  return await (0, _HEutil.createServerHEContext)(polyModulusDegree, plainModulusBitSize, securityLevel, compressionMode);
 }
 
 function getZeroFilledBigUint64Array(length) {
@@ -127,13 +139,13 @@ function getRedundantPartsRemovedArray(arr, slotCount) {
 
 
 function decrypt(encryptedResult, {
-  morfix,
+  seal,
   context,
   decryptor,
   encoder
 }) {
   const resultVec = encryptedResult.map(encRes => {
-    const cipherText = morfix.CipherText();
+    const cipherText = seal.CipherText();
     cipherText.load(context, encRes);
     const noiseBudget = decryptor.invariantNoiseBudget(cipherText);
 
@@ -174,15 +186,15 @@ function decryptServerResponseObject(serverResponseObject, clientContext) {
 
 function compute(encryptedArray, serializedGaloisKeys, matrix, serverContext) {
   const {
-    morfix,
+    seal,
     context,
     encoder
   } = serverContext;
-  const galoisKeys = morfix.GaloisKeys();
+  const galoisKeys = seal.GaloisKeys();
   galoisKeys.load(context, serializedGaloisKeys);
   serverContext.galois = galoisKeys;
   const input = encryptedArray.map(inpt => {
-    const cipherText = morfix.CipherText();
+    const cipherText = seal.CipherText();
     cipherText.load(context, inpt);
     return cipherText;
   });

--- a/test/compression.test.js
+++ b/test/compression.test.js
@@ -1,51 +1,43 @@
 import PSA from '../src'
 
-describe('an psa lib', () => {
-  it('passed compression parameter: "none"', async () => {
-    const polyModulusDegree = 4096
-    const plainModulus = 20
-    const clientContext = await PSA.getClientContext(
-      polyModulusDegree,
-      plainModulus,
-      'none'
-    )
+describe('compression mode settings', () => {
+  it('should initialize with compression mode: none', async () => {
+    const clientContext = await PSA.getClientContext({
+      polyModulusDegree: 4096,
+      plainModulusBitSize: 20,
+      compressionMode: 'none'
+    })
     expect(clientContext.compression).toBe(
-      clientContext.morfix.ComprModeType.none
+      clientContext.seal.ComprModeType.none
     )
   })
-  it('passed compression parameter: "zlib"', async () => {
-    const polyModulusDegree = 4096
-    const plainModulus = 20
-    const clientContext = await PSA.getClientContext(
-      polyModulusDegree,
-      plainModulus,
-      'zlib'
-    )
+  it('should initialize with compression mode: zlib', async () => {
+    const clientContext = await PSA.getClientContext({
+      polyModulusDegree: 4096,
+      plainModulusBitSize: 20,
+      compressionMode: 'zlib'
+    })
     expect(clientContext.compression).toBe(
-      clientContext.morfix.ComprModeType.zlib
+      clientContext.seal.ComprModeType.zlib
     )
   })
-  it('passed compression parameter: "zstd"', async () => {
-    const polyModulusDegree = 4096
-    const plainModulus = 20
-    const clientContext = await PSA.getClientContext(
-      polyModulusDegree,
-      plainModulus,
-      'zstd'
-    )
+  it('should initialize with compression mode: zstd', async () => {
+    const clientContext = await PSA.getClientContext({
+      polyModulusDegree: 4096,
+      plainModulusBitSize: 20,
+      compressionMode: 'zstd'
+    })
     expect(clientContext.compression).toBe(
-      clientContext.morfix.ComprModeType.zstd
+      clientContext.seal.ComprModeType.zstd
     )
   })
-  it('passed compression parameter: undefined', async () => {
-    const polyModulusDegree = 4096
-    const plainModulus = 20
-    const clientContext = await PSA.getClientContext(
-      polyModulusDegree,
-      plainModulus
-    )
+  it('should initialize with a default compression mode (zstd): undefined', async () => {
+    const clientContext = await PSA.getClientContext({
+      polyModulusDegree: 4096,
+      plainModulusBitSize: 20
+    })
     expect(clientContext.compression).toBe(
-      clientContext.morfix.ComprModeType.zstd
+      clientContext.seal.ComprModeType.zstd
     )
   })
 })

--- a/test/security_level.test.js
+++ b/test/security_level.test.js
@@ -1,0 +1,83 @@
+import PSA from '../src'
+
+describe('security level settings', () => {
+  it('should initialize with a security level: 128', async () => {
+    const clientContext = await PSA.getClientContext({
+      polyModulusDegree: 4096,
+      plainModulusBitSize: 20,
+      securityLevel: 128
+    })
+    const expectedCoeffModulus = BigUint64Array.from([
+      '68719403009',
+      '68719230977',
+      '137438822401'
+    ])
+    const context = clientContext.context
+    const contextData = context.keyContextData
+    const parms = contextData.parms
+    const coeffModulus = parms.coeffModulus
+    parms.delete()
+    contextData.delete()
+    context.delete()
+    expect(expectedCoeffModulus).toEqual(coeffModulus)
+  })
+  it('should initialize with a security level: 192', async () => {
+    const clientContext = await PSA.getClientContext({
+      polyModulusDegree: 4096,
+      plainModulusBitSize: 20,
+      securityLevel: 192
+    })
+    const expectedCoeffModulus = BigUint64Array.from([
+      '33538049',
+      '33349633',
+      '33292289'
+    ])
+    const context = clientContext.context
+    const contextData = context.keyContextData
+    const parms = contextData.parms
+    const coeffModulus = parms.coeffModulus
+    parms.delete()
+    contextData.delete()
+    context.delete()
+    expect(expectedCoeffModulus).toEqual(coeffModulus)
+  })
+  it('should initialize with a security level: 256', async () => {
+    const clientContext = await PSA.getClientContext({
+      polyModulusDegree: 8192,
+      plainModulusBitSize: 20,
+      securityLevel: 256
+    })
+    const expectedCoeffModulus = BigUint64Array.from([
+      '549755731969',
+      '549755486209',
+      '1099511480321'
+    ])
+    const context = clientContext.context
+    const contextData = context.keyContextData
+    const parms = contextData.parms
+    const coeffModulus = parms.coeffModulus
+    parms.delete()
+    contextData.delete()
+    context.delete()
+    expect(expectedCoeffModulus).toEqual(coeffModulus)
+  })
+  it('should initialize with a default security level (128): undefined', async () => {
+    const clientContext = await PSA.getClientContext({
+      polyModulusDegree: 4096,
+      plainModulusBitSize: 20
+    })
+    const expectedCoeffModulus = BigUint64Array.from([
+      '68719403009',
+      '68719230977',
+      '137438822401'
+    ])
+    const context = clientContext.context
+    const contextData = context.keyContextData
+    const parms = contextData.parms
+    const coeffModulus = parms.coeffModulus
+    parms.delete()
+    contextData.delete()
+    context.delete()
+    expect(expectedCoeffModulus).toEqual(coeffModulus)
+  })
+})

--- a/test/with_network.test.js
+++ b/test/with_network.test.js
@@ -5,22 +5,25 @@ describe('an psa lib', () => {
     'with networking object (compression: %s)',
     async compressionMode => {
       const polyModulusDegree = 4096
-      const plainModulus = 20
-      const clientContext = await PSA.getClientContext(
+      const plainModulusBitSize = 20
+
+      const clientContext = await PSA.getClientContext({
         polyModulusDegree,
-        plainModulus,
+        plainModulusBitSize,
         compressionMode
-      )
+      })
+
       expect(clientContext.compression).toBe(
-        clientContext.morfix.ComprModeType[compressionMode]
+        clientContext.seal.ComprModeType[compressionMode]
       )
-      const serverContext = await PSA.getServerContext(
+
+      const serverContext = await PSA.getServerContext({
         polyModulusDegree,
-        plainModulus,
+        plainModulusBitSize,
         compressionMode
-      )
+      })
       expect(serverContext.compression).toBe(
-        serverContext.morfix.ComprModeType[compressionMode]
+        serverContext.seal.ComprModeType[compressionMode]
       )
       // prettier-ignore
       const array = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26,
@@ -47,7 +50,7 @@ describe('an psa lib', () => {
       // ------------------ TEST---------
       const computationResult = JSON.parse(serverResponse)
       for (let i = 0; i < computationResult.length; ++i) {
-        const cipherText = clientContext.morfix.CipherText()
+        const cipherText = clientContext.seal.CipherText()
         cipherText.load(clientContext.context, computationResult[i])
         const noiseBudget = clientContext.decryptor.invariantNoiseBudget(
           cipherText

--- a/test/without_network.test.js
+++ b/test/without_network.test.js
@@ -5,23 +5,22 @@ describe('an psa lib', () => {
     'without networking object (compression: %s)',
     async compressionMode => {
       const polyModulusDegree = 4096
-      const plainModulus = 20
-      const clientContext = await PSA.getClientContext(
+      const plainModulusBitSize = 20
+      const clientContext = await PSA.getClientContext({
         polyModulusDegree,
-        plainModulus,
+        plainModulusBitSize,
         compressionMode
-      )
+      })
+
       expect(clientContext.compression).toBe(
-        clientContext.morfix.ComprModeType[compressionMode]
+        clientContext.seal.ComprModeType[compressionMode]
       )
-      const serverContext = await PSA.getServerContext(
+
+      const serverContext = await PSA.getServerContext({
         polyModulusDegree,
-        plainModulus,
+        plainModulusBitSize,
         compressionMode
-      )
-      expect(serverContext.compression).toBe(
-        serverContext.morfix.ComprModeType[compressionMode]
-      )
+      })
       // prettier-ignore
       const array = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26,
             27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53,
@@ -47,7 +46,7 @@ describe('an psa lib', () => {
 
       // ------------------ TEST---------
       for (let i = 0; i < out.length; ++i) {
-        const cipherText = clientContext.morfix.CipherText({
+        const cipherText = clientContext.seal.CipherText({
           context: clientContext.context
         })
         cipherText.load(clientContext.context, out[i])


### PR DESCRIPTION
This PR allows for the user to specify a security level override. It also removes the statically defined CoeffModulus bit sizes in favor of using the `BFVDefault` function which does the same thing internally, therefore reducing the unnecessary code.

In addition, we change the input arguments to the server context to an object containing key/values. This allows for easier optionals and doesn't require the user to input the args in a specific order.

In summary, the user can now specify an optional security level and compression mode which both default to 128 bits (`tc128`) and zstandard (`zstd`) respectively.