### PR TITLE
Update node-seal

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ The plaintext modulus can be set arbitrarily. However, applications in the past,
 For users who don't know how to choose the parameters, I recommend using 4096 as the polymodulus degree and 20 as the
 plaintext modulus. If the noise budget gets consumed, try using the next higher polymodulus degree.
 
-**Note:** The application may run out of memory with a polymodulus degree of 16384. A solution could to specify a
+**Note:** The application may run out of memory with a polymodulus degree of 16384. A solution could be to specify a
 different compression mode such as 'none' or the slower 'zlib' over the default 'zstd'. In addition, you may need to
 increase the JavaScript heap size by adding `--max-old-space-size=4096` for NodeJS.
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ The plaintext modulus can be set arbitrarily. However, applications in the past,
 For users who don't know how to choose the parameters, I recommend using 4096 as the polymodulus degree and 20 as the
 plaintext modulus. If the noise budget gets consumed, try using the next higher polymodulus degree.
 
-**Note:** The application may run out of memory with a polymodulus degree of 8192 or 16384. A solution is to specify a
+**Note:** The application may run out of memory with a polymodulus degree of 16384. A solution could to specify a
 different compression mode such as 'none' or the slower 'zlib' over the default 'zstd'. In addition, you may need to
 increase the JavaScript heap size by adding `--max-old-space-size=4096` for NodeJS.
 

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "url": "https://github.com/Safe-DEED/PSA"
   },
   "dependencies": {
-    "node-seal": "^4.5.1"
+    "node-seal": "^4.5.2"
   },
   "devDependencies": {
     "@babel/cli": "^7.12.8",

--- a/src/HEutil.js
+++ b/src/HEutil.js
@@ -10,6 +10,13 @@ var _allows_wasm_node_umd = _interopRequireDefault(require("node-seal/allows_was
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
+/**
+ * Creates a SEAL context
+ * @param {number} polyModulusDegree
+ * @param {number} securityLevel
+ * @param {number} plainModulusBitSize
+ * @returns {Promise<[Object, Object]>}
+ */
 async function createHEContext(polyModulusDegree, securityLevel, plainModulusBitSize) {
   const seal = await (0, _allows_wasm_node_umd.default)();
   const schemeType = seal.SchemeType.bfv;
@@ -38,6 +45,15 @@ async function createHEContext(polyModulusDegree, securityLevel, plainModulusBit
 
   return [seal, context];
 }
+/**
+ * Create a client context
+ * @param {number} polyModulusDegree
+ * @param {number} plainModulus
+ * @param {number} securityLevel
+ * @param {string} compressionMode
+ * @returns {Promise<Object>}
+ */
+
 
 async function createClientHEContext(polyModulusDegree, plainModulus, securityLevel, compressionMode) {
   const [seal, context] = await createHEContext(polyModulusDegree, securityLevel, plainModulus);
@@ -68,6 +84,15 @@ async function createClientHEContext(polyModulusDegree, plainModulus, securityLe
     evaluator
   };
 }
+/**
+ * Create a server context
+ * @param {number} polyModulusDegree
+ * @param {number} plainModulus
+ * @param {number} securityLevel
+ * @param {string} compressionMode
+ * @returns {Promise<Object>}
+ */
+
 
 async function createServerHEContext(polyModulusDegree, plainModulus, securityLevel, compressionMode) {
   const [seal, context] = await createHEContext(polyModulusDegree, securityLevel, plainModulus);
@@ -82,6 +107,14 @@ async function createServerHEContext(polyModulusDegree, plainModulus, securityLe
     evaluator
   };
 }
+/**
+ * Gets the SEAL security enum from a number mapping
+ * @param {number} securityLevel
+ * @param {Object} options
+ * @param {Object} options.SecurityLevel
+ * @returns {Object}
+ */
+
 
 function getSecurityLevel(securityLevel, {
   SecurityLevel
@@ -100,6 +133,14 @@ function getSecurityLevel(securityLevel, {
       return SecurityLevel.tc128;
   }
 }
+/**
+ * Gets the SEAL compression enum from a string mapping
+ * @param {string} compression
+ * @param {Object} options
+ * @param {Object} options.ComprModeType
+ * @returns {Object}
+ */
+
 
 function getComprModeType(compression, {
   ComprModeType

--- a/src/HEutil.mjs
+++ b/src/HEutil.mjs
@@ -1,5 +1,12 @@
 import SEAL from 'node-seal/allows_wasm_node_umd'
 
+/**
+ * Creates a SEAL context
+ * @param {number} polyModulusDegree
+ * @param {number} securityLevel
+ * @param {number} plainModulusBitSize
+ * @returns {Promise<[Object, Object]>}
+ */
 async function createHEContext(
   polyModulusDegree,
   securityLevel,
@@ -45,6 +52,14 @@ async function createHEContext(
   return [seal, context]
 }
 
+/**
+ * Create a client context
+ * @param {number} polyModulusDegree
+ * @param {number} plainModulus
+ * @param {number} securityLevel
+ * @param {string} compressionMode
+ * @returns {Promise<Object>}
+ */
 export async function createClientHEContext(
   polyModulusDegree,
   plainModulus,
@@ -86,6 +101,14 @@ export async function createClientHEContext(
   }
 }
 
+/**
+ * Create a server context
+ * @param {number} polyModulusDegree
+ * @param {number} plainModulus
+ * @param {number} securityLevel
+ * @param {string} compressionMode
+ * @returns {Promise<Object>}
+ */
 export async function createServerHEContext(
   polyModulusDegree,
   plainModulus,
@@ -104,6 +127,13 @@ export async function createServerHEContext(
   return { seal, compression, context, encoder, evaluator }
 }
 
+/**
+ * Gets the SEAL security enum from a number mapping
+ * @param {number} securityLevel
+ * @param {Object} options
+ * @param {Object} options.SecurityLevel
+ * @returns {Object}
+ */
 function getSecurityLevel(securityLevel, { SecurityLevel }) {
   switch (securityLevel) {
     case 128:
@@ -117,6 +147,13 @@ function getSecurityLevel(securityLevel, { SecurityLevel }) {
   }
 }
 
+/**
+ * Gets the SEAL compression enum from a string mapping
+ * @param {string} compression
+ * @param {Object} options
+ * @param {Object} options.ComprModeType
+ * @returns {Object}
+ */
 function getComprModeType(compression, { ComprModeType }) {
   switch (compression) {
     case 'none':

--- a/src/index.js
+++ b/src/index.js
@@ -227,14 +227,12 @@ function compute(encryptedArray, serializedGaloisKeys, matrix, serverContext) {
     k,
     bsgsN1,
     bsgsN2
-  }, serverContext); // cleanup
+  }, serverContext);
+  const serialized = output.map(item => item.save(serverContext.compression)); // Clean up WASM instances
 
   input.forEach(x => x.delete());
-  return output.map(item => {
-    const serialized = item.save(serverContext.compression);
-    item.delete();
-    return serialized;
-  });
+  output.forEach(x => x.delete());
+  return serialized;
 }
 /**
  * This function returns the serialized galois key needed for rotations of the ciphertext.
@@ -270,6 +268,7 @@ function computeWithClientRequestObject(clientRequestObject, matrix, serverConte
  * @param {Object} options
  * @param {Object} options.compression
  * @param {Object} options.galoisKeys
+ * @returns {string}
  */
 
 

--- a/src/index.js
+++ b/src/index.js
@@ -258,10 +258,10 @@ function getSerializedGaloisKeys(clientContext) {
 
 function computeWithClientRequestObject(clientRequestObject, matrix, serverContext) {
   const {
-    arr,
+    encryptedArray,
     galois
   } = JSON.parse(clientRequestObject);
-  const computationResult = compute(arr, galois, matrix, serverContext);
+  const computationResult = compute(encryptedArray, galois, matrix, serverContext);
   return getServerResponseObject(computationResult);
 }
 /**
@@ -280,7 +280,7 @@ function getClientRequestObject(encryptedArray, {
 }) {
   const galois = galoisKeys.save(compression);
   return JSON.stringify({
-    arr: encryptedArray,
+    encryptedArray,
     galois
   });
 }

--- a/src/index.js
+++ b/src/index.js
@@ -227,12 +227,14 @@ function compute(encryptedArray, serializedGaloisKeys, matrix, serverContext) {
     k,
     bsgsN1,
     bsgsN2
-  }, serverContext);
-  const serialized = output.map(item => item.save(serverContext.compression)); // Clean up WASM instances
+  }, serverContext); // Clean up WASM instances
 
   input.forEach(x => x.delete());
-  output.forEach(x => x.delete());
-  return serialized;
+  return output.map(item => {
+    const serialized = item.save(serverContext.compression);
+    item.delete();
+    return serialized;
+  });
 }
 /**
  * This function returns the serialized galois key needed for rotations of the ciphertext.

--- a/src/index.js
+++ b/src/index.js
@@ -230,6 +230,7 @@ function compute(encryptedArray, serializedGaloisKeys, matrix, serverContext) {
   }, serverContext); // Clean up WASM instances
 
   input.forEach(x => x.delete());
+  serverContext.galois.delete();
   return output.map(item => {
     const serialized = item.save(serverContext.compression);
     item.delete();

--- a/src/index.js
+++ b/src/index.js
@@ -92,7 +92,7 @@ function getNumberOfInnerArrays(numberOfIdentities, slotCount) {
  * This function encrypts the client's input vector and returns an array of ciphertexts.
  * @param {number[]} inputArray 1D array of numbers
  * @param {Object} clientContext client side context
- * @returns {string[]} an array of ciphertexts
+ * @returns {string[]} an array of serialized ciphertexts
  */
 
 

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -212,11 +212,13 @@ function compute(encryptedArray, serializedGaloisKeys, matrix, serverContext) {
     { N, k, bsgsN1, bsgsN2 },
     serverContext
   )
-  const serialized = output.map(item => item.save(serverContext.compression))
   // Clean up WASM instances
   input.forEach(x => x.delete())
-  output.forEach(x => x.delete())
-  return serialized
+  return output.map(item => {
+    const serialized = item.save(serverContext.compression)
+    item.delete()
+    return serialized
+  })
 }
 
 /**

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -86,7 +86,7 @@ function getNumberOfInnerArrays(numberOfIdentities, slotCount) {
  * This function encrypts the client's input vector and returns an array of ciphertexts.
  * @param {number[]} inputArray 1D array of numbers
  * @param {Object} clientContext client side context
- * @returns {string[]} an array of ciphertexts
+ * @returns {string[]} an array of serialized ciphertexts
  */
 function encrypt(inputArray, { compression, encoder, encryptor }) {
   const numInnerArrays = getNumberOfInnerArrays(

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -212,13 +212,11 @@ function compute(encryptedArray, serializedGaloisKeys, matrix, serverContext) {
     { N, k, bsgsN1, bsgsN2 },
     serverContext
   )
-  // cleanup
+  const serialized = output.map(item => item.save(serverContext.compression))
+  // Clean up WASM instances
   input.forEach(x => x.delete())
-  return output.map(item => {
-    const serialized = item.save(serverContext.compression)
-    item.delete()
-    return serialized
-  })
+  output.forEach(x => x.delete())
+  return serialized
 }
 
 /**
@@ -254,6 +252,7 @@ function computeWithClientRequestObject(
  * @param {Object} options
  * @param {Object} options.compression
  * @param {Object} options.galoisKeys
+ * @returns {string}
  */
 function getClientRequestObject(encryptedArray, { compression, galoisKeys }) {
   const galois = galoisKeys.save(compression)

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -45,16 +45,28 @@ async function getServerContext({
   )
 }
 
+/**
+ * Generate a zero-filled BigUint64Array
+ * @param {number} length The size of the array
+ * @returns {BigUint64Array}
+ */
 function getZeroFilledBigUint64Array(length) {
   return BigUint64Array.from({ length }, _ => BigInt(0))
 }
 
-function getSpecialFormatIndicesVector(numInnerArrays, encoder, vec) {
+/**
+ * Get the special format for the indices
+ * @param {number} numInnerArrays
+ * @param {number} slotCount The SEAL encoder slot count
+ * @param {number[]} vec
+ * @returns {BigUint64Array[]}
+ */
+function getSpecialFormatIndicesVector(numInnerArrays, slotCount, vec) {
   const numberIndices = []
   for (let i = 0; i < numInnerArrays; ++i) {
-    const inner_array = getZeroFilledBigUint64Array(encoder.slotCount)
-    const currentOffset = i * encoder.slotCount
-    for (let innerI = 0; innerI < encoder.slotCount; ++innerI) {
+    const inner_array = getZeroFilledBigUint64Array(slotCount)
+    const currentOffset = i * slotCount
+    for (let innerI = 0; innerI < slotCount; ++innerI) {
       if (currentOffset + innerI < vec.length) {
         inner_array[innerI] = BigInt(vec[currentOffset + innerI])
       } else {
@@ -72,9 +84,9 @@ function getNumberOfInnerArrays(numberOfIdentities, slotCount) {
 
 /**
  * This function encrypts the client's input vector and returns an array of ciphertexts.
- * @param {array<number>} inputArray 1D array of numbers
+ * @param {number[]} inputArray 1D array of numbers
  * @param {Object} clientContext client side context
- * @returns {array<CipherText>} an array of ciphertexts
+ * @returns {string[]} an array of ciphertexts
  */
 function encrypt(inputArray, { compression, encoder, encryptor }) {
   const numInnerArrays = getNumberOfInnerArrays(
@@ -83,7 +95,7 @@ function encrypt(inputArray, { compression, encoder, encryptor }) {
   )
   const numberIndices = getSpecialFormatIndicesVector(
     numInnerArrays,
-    encoder,
+    encoder.slotCount,
     inputArray
   )
 
@@ -106,7 +118,7 @@ function encrypt(inputArray, { compression, encoder, encryptor }) {
 
 /**
  * This function encrypts the client's input vector and returns an object ready to be sent to the server.
- * @param {array<number>} inputArray 1D array of numbers
+ * @param {number[]} inputArray 1D array of numbers
  * @param {Object} clientContext client side context
  * @returns {string} JSON to be sent to server without further processing
  */
@@ -115,6 +127,12 @@ function encryptForClientRequest(inputArray, clientContext) {
   return getClientRequestObject(encryptedArray, clientContext)
 }
 
+/**
+ * Get the relevant parts from the input array
+ * @param {bigint[]} arr
+ * @param {number} slotCount
+ * @returns {bigint[]}
+ */
 function getRedundantPartsRemovedArray(arr, slotCount) {
   const flatArray = []
   for (let i = 0; i < arr.length; ++i) {
@@ -127,9 +145,9 @@ function getRedundantPartsRemovedArray(arr, slotCount) {
 
 /**
  * This function decrypts the computed result vector. The result will be in the first n cells, if the matrix was of dimension (m x n).
- * @param {array<CipherText>} encryptedResult 1D array of ciphertexts received from server computation
+ * @param {string[]} encryptedResult 1D array of serialized ciphertexts received from server computation
  * @param {Object} clientContext client side context
- * @returns {array<number>} resulting array
+ * @returns {number[]} resulting array
  */
 function decrypt(encryptedResult, { seal, context, decryptor, encoder }) {
   const resultVec = encryptedResult.map(encRes => {
@@ -155,7 +173,7 @@ function decrypt(encryptedResult, { seal, context, decryptor, encoder }) {
  * This function decrypts the server response object. The result will be in the first n cells, if the matrix was of dimension (m x n).
  * @param {string} serverResponseObject server response object (JSON), received from the server
  * @param {Object} clientContext client side context
- * @returns {array<number>} resulting array
+ * @returns {number[]} resulting array
  */
 function decryptServerResponseObject(serverResponseObject, clientContext) {
   const encryptedResult = JSON.parse(serverResponseObject)
@@ -165,11 +183,11 @@ function decryptServerResponseObject(serverResponseObject, clientContext) {
 /**
  * This function computes the dot product between the encrypted client vector and the server matrix.
  * Constraints: If vector is of dimensions (1 x m), then matrix has to be of (m x n).
- * @param {array<CipherText>} encryptedArray 1D array of ciphertexts received from client
+ * @param {string[]} encryptedArray 1D array of serialized ciphertexts received from client
  * @param {string} serializedGaloisKeys base64 encoded galois key
- * @param {array<number>} matrix a 2D array of Numbers.
+ * @param {number[]} matrix a 2D array of Numbers.
  * @param {Object} serverContext server side context
- * @returns {array<CipherText>} an array of ciphertexts
+ * @returns {string[]} an array of serialized ciphertexts
  */
 function compute(encryptedArray, serializedGaloisKeys, matrix, serverContext) {
   const { seal, context, encoder } = serverContext
@@ -196,7 +214,11 @@ function compute(encryptedArray, serializedGaloisKeys, matrix, serverContext) {
   )
   // cleanup
   input.forEach(x => x.delete())
-  return output.map(item => item.save(serverContext.compression))
+  return output.map(item => {
+    const serialized = item.save(serverContext.compression)
+    item.delete()
+    return serialized
+  })
 }
 
 /**
@@ -212,7 +234,7 @@ function getSerializedGaloisKeys(clientContext) {
  * This function computes the dot product between the encrypted client vector and the server matrix.
  * Constraints: If vector is of dimensions (1 x m), then matrix has to be of (m x n).
  * @param {string} clientRequestObject client request object (JSON), received from client
- * @param {array<number>} matrix a 2D array of Numbers.
+ * @param {number[]} matrix a 2D array of Numbers.
  * @param {Object} serverContext server side context
  * @returns {string} JSON to be sent to client for decryption
  */
@@ -226,11 +248,23 @@ function computeWithClientRequestObject(
   return getServerResponseObject(computationResult)
 }
 
+/**
+ *
+ * @param {string[]} encryptedArray
+ * @param {Object} options
+ * @param {Object} options.compression
+ * @param {Object} options.galoisKeys
+ */
 function getClientRequestObject(encryptedArray, { compression, galoisKeys }) {
   const galois = galoisKeys.save(compression)
   return JSON.stringify({ arr: encryptedArray, galois })
 }
 
+/**
+ * Stringify a server response
+ * @param {string[]} computationResult
+ * @returns {string}
+ */
 function getServerResponseObject(computationResult) {
   return JSON.stringify(computationResult)
 }

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -243,8 +243,13 @@ function computeWithClientRequestObject(
   matrix,
   serverContext
 ) {
-  const { arr, galois } = JSON.parse(clientRequestObject)
-  const computationResult = compute(arr, galois, matrix, serverContext)
+  const { encryptedArray, galois } = JSON.parse(clientRequestObject)
+  const computationResult = compute(
+    encryptedArray,
+    galois,
+    matrix,
+    serverContext
+  )
   return getServerResponseObject(computationResult)
 }
 
@@ -258,7 +263,7 @@ function computeWithClientRequestObject(
  */
 function getClientRequestObject(encryptedArray, { compression, galoisKeys }) {
   const galois = galoisKeys.save(compression)
-  return JSON.stringify({ arr: encryptedArray, galois })
+  return JSON.stringify({ encryptedArray, galois })
 }
 
 /**

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -214,6 +214,7 @@ function compute(encryptedArray, serializedGaloisKeys, matrix, serverContext) {
   )
   // Clean up WASM instances
   input.forEach(x => x.delete())
+  serverContext.galois.delete()
   return output.map(item => {
     const serialized = item.save(serverContext.compression)
     item.delete()


### PR DESCRIPTION
This PR updates `node-seal` to the latest version which addresses [this](https://github.com/microsoft/SEAL/issues/248) bug in Microsoft SEAL.

The default 'zstd' compression works as expected and users no longer need to switch compression modes for `polyModulusDegree` of 8192 or 16384. 

In addition, we fix JSDoc syntax along with a small memory leak in the psa-lib.

PR in draft for performance testing.